### PR TITLE
Enhancement/repl

### DIFF
--- a/include/Ark/Ark.hpp
+++ b/include/Ark/Ark.hpp
@@ -6,5 +6,6 @@
 #include <Ark/Utils.hpp>
 #include <Ark/VM/VM.hpp>
 #include <Ark/Compiler/Compiler.hpp>
+#include <Ark/REPL/Repl.hpp>
 
 #endif  // ark_ark

--- a/include/Ark/REPL/Repl.hpp
+++ b/include/Ark/REPL/Repl.hpp
@@ -1,0 +1,14 @@
+#ifndef ark_repl
+#define ark_repl
+
+#include <iostream>
+
+namespace Ark {
+    class Repl {
+    public:
+        Repl();
+        void run();
+    };
+}
+
+#endif

--- a/include/Ark/REPL/Repl.hpp
+++ b/include/Ark/REPL/Repl.hpp
@@ -5,6 +5,9 @@
 #include <sstream>
 
 #include <Ark/Constants.hpp>
+#include <Ark/Compiler/Compiler.hpp>
+#include <Ark/VM/VM.hpp>
+#include <Ark/VM/State.hpp>
 
 namespace Ark {
     class Repl {
@@ -17,6 +20,7 @@ namespace Ark {
 
         inline void print_repl_header();
         int count_open_parentheses(std::string line);
+        int count_open_braces(std::string line);
     };
 }
 

--- a/include/Ark/REPL/Repl.hpp
+++ b/include/Ark/REPL/Repl.hpp
@@ -2,12 +2,21 @@
 #define ark_repl
 
 #include <iostream>
+#include <sstream>
+
+#include <Ark/Constants.hpp>
 
 namespace Ark {
     class Repl {
     public:
-        Repl();
+        Repl(uint16_t options) : m_options(options) {};
         void run();
+
+    private:
+        uint16_t m_options;
+
+        void print_repl_header();
+        int count_open_parentheses(std::string line);
     };
 }
 

--- a/include/Ark/REPL/Repl.hpp
+++ b/include/Ark/REPL/Repl.hpp
@@ -9,8 +9,10 @@
 #include <Ark/VM/VM.hpp>
 #include <Ark/VM/State.hpp>
 
-namespace Ark {
-    class Repl {
+namespace Ark 
+{
+    class Repl 
+    {
     public:
         Repl(uint16_t options, std::string lib_dir) : 
             m_options(options), m_lib_dir(lib_dir) {};

--- a/include/Ark/REPL/Repl.hpp
+++ b/include/Ark/REPL/Repl.hpp
@@ -23,8 +23,8 @@ namespace Ark
         uint16_t m_options;
 
         inline void print_repl_header();
-        int count_open_parentheses(std::string line);
-        int count_open_braces(std::string line);
+        int count_open_parentheses(std::string& line);
+        int count_open_braces(std::string& line);
     };
 }
 

--- a/include/Ark/REPL/Repl.hpp
+++ b/include/Ark/REPL/Repl.hpp
@@ -12,10 +12,12 @@
 namespace Ark {
     class Repl {
     public:
-        Repl(uint16_t options) : m_options(options) {};
+        Repl(uint16_t options, std::string lib_dir) : 
+            m_options(options), m_lib_dir(lib_dir) {};
         void run();
 
     private:
+        std::string m_lib_dir;
         uint16_t m_options;
 
         inline void print_repl_header();

--- a/include/Ark/REPL/Repl.hpp
+++ b/include/Ark/REPL/Repl.hpp
@@ -9,9 +9,9 @@
 #include <Ark/VM/VM.hpp>
 #include <Ark/VM/State.hpp>
 
-namespace Ark 
+namespace Ark
 {
-    class Repl 
+    class Repl
     {
     public:
         Repl(uint16_t options, std::string lib_dir) : 

--- a/include/Ark/REPL/Repl.hpp
+++ b/include/Ark/REPL/Repl.hpp
@@ -15,7 +15,7 @@ namespace Ark {
     private:
         uint16_t m_options;
 
-        void print_repl_header();
+        inline void print_repl_header();
         int count_open_parentheses(std::string line);
     };
 }

--- a/src/REPL/Repl.cpp
+++ b/src/REPL/Repl.cpp
@@ -38,7 +38,7 @@ namespace Ark {
         }
     }
 
-    void Repl::print_repl_header()
+    inline void Repl::print_repl_header()
     {
         std::cout << "ArkScript REPL -- ";
         std::cout << "Version " << ARK_VERSION_MAJOR << "." << ARK_VERSION_MINOR << "." << ARK_VERSION_PATCH << " ";

--- a/src/REPL/Repl.cpp
+++ b/src/REPL/Repl.cpp
@@ -1,0 +1,11 @@
+#include <Ark/REPL/Repl.hpp>
+
+namespace Ark {
+    Repl::Repl() {
+        std::cout << "Initiated...\n";
+    }
+    
+    void Repl::run() {
+        std::cout << "Hello!";
+    }
+}

--- a/src/REPL/Repl.cpp
+++ b/src/REPL/Repl.cpp
@@ -8,33 +8,65 @@ namespace Ark {
 
         print_repl_header();
 
+
         while(true)
         {
+            Ark::Compiler compiler(false);
+            Ark::State state(".");
+            Ark::VM vm(&state, m_options);
+            state.setDebug(false);
+
             std::stringstream code;
             int open_parentheses = 0;
+            int open_braces = 0;
+            bool new_command = true;
 
             std::cout << new_prompt;
-
             for(std::string line; std::getline(std::cin, line);)
             {
+                if (line.length() == 0)
+                {
+                    std::cout << (new_command ? new_prompt : continuing_prompt);
+                    continue;
+                }
+
                 if (line.compare("(quit)") == 0)
                 {
                     return;
                 }
 
-                code << line;
-
+                code << line << "\n";
                 open_parentheses += count_open_parentheses(line);
+                open_braces += count_open_braces(line);
 
-                if (open_parentheses == 0)
+                if (open_parentheses == 0 && open_braces == 0)
                 {
                     break;
                 }
 
+                new_command = false;
                 std::cout << continuing_prompt;
             }
 
-            std::cout << code.str() << "\n";
+            try
+            {
+                compiler.feed("{" + code.str() + "}");
+                compiler.compile();
+
+                state.feed(compiler.bytecode());
+                vm.run();
+            }
+            catch (const std::runtime_error& e) {
+                std::cerr << e.what() << std::endl;
+            }
+            catch (const std::exception& e)
+            {
+                std::cerr << e.what() << std::endl;
+            }
+            catch (...)
+            {
+                std::cerr << "Unknown lexer-parser-or-compiler error" << std::endl;
+            }
         }
     }
 
@@ -42,8 +74,8 @@ namespace Ark {
     {
         std::cout << "ArkScript REPL -- ";
         std::cout << "Version " << ARK_VERSION_MAJOR << "." << ARK_VERSION_MINOR << "." << ARK_VERSION_PATCH << " ";
-        std::cout << "[LICENSE: Mozilla Public License 2.0]\n";
-        std::cout << "Type \"(quit)\" to quit.\n";
+        std::cout << "[LICENSE: Mozilla Public License 2.0]" << std::endl;
+        std::cout << "Type \"(quit)\" to quit." << std::endl;
     }
 
     int Repl::count_open_parentheses(std::string line)
@@ -60,5 +92,21 @@ namespace Ark {
         }
 
         return open_parentheses;
+    }
+
+    int Repl::count_open_braces(std::string line)
+    {
+        int open_braces = 0;
+
+        for(char& c: line)
+        {
+            switch(c)
+            {
+                case '{': open_braces++; break;
+                case '}': open_braces--; break;
+            }
+        }
+
+        return open_braces;
     }
 }

--- a/src/REPL/Repl.cpp
+++ b/src/REPL/Repl.cpp
@@ -78,7 +78,7 @@ namespace Ark
         std::cout << "Type \"(quit)\" to quit." << std::endl;
     }
 
-    int Repl::count_open_parentheses(std::string line)
+    int Repl::count_open_parentheses(std::string& line)
     {
         int open_parentheses = 0;
 
@@ -94,7 +94,7 @@ namespace Ark
         return open_parentheses;
     }
 
-    int Repl::count_open_braces(std::string line)
+    int Repl::count_open_braces(std::string& line)
     {
         int open_braces = 0;
 

--- a/src/REPL/Repl.cpp
+++ b/src/REPL/Repl.cpp
@@ -8,11 +8,10 @@ namespace Ark {
 
         print_repl_header();
 
-
         while(true)
         {
             Ark::Compiler compiler(false);
-            Ark::State state(".");
+            Ark::State state(m_lib_dir);
             Ark::VM vm(&state, m_options);
             state.setDebug(false);
 

--- a/src/REPL/Repl.cpp
+++ b/src/REPL/Repl.cpp
@@ -1,11 +1,64 @@
 #include <Ark/REPL/Repl.hpp>
 
 namespace Ark {
-    Repl::Repl() {
-        std::cout << "Initiated...\n";
+    void Repl::run()
+    {
+        const std::string new_prompt = ">> ";
+        const std::string continuing_prompt = ".. ";
+
+        print_repl_header();
+
+        while(true)
+        {
+            std::stringstream code;
+            int open_parentheses = 0;
+
+            std::cout << new_prompt;
+
+            for(std::string line; std::getline(std::cin, line);)
+            {
+                if (line.compare("(quit)") == 0)
+                {
+                    return;
+                }
+
+                code << line;
+
+                open_parentheses += count_open_parentheses(line);
+
+                if (open_parentheses == 0)
+                {
+                    break;
+                }
+
+                std::cout << continuing_prompt;
+            }
+
+            std::cout << code.str() << "\n";
+        }
     }
-    
-    void Repl::run() {
-        std::cout << "Hello!";
+
+    void Repl::print_repl_header()
+    {
+        std::cout << "ArkScript REPL -- ";
+        std::cout << "Version " << ARK_VERSION_MAJOR << "." << ARK_VERSION_MINOR << "." << ARK_VERSION_PATCH << " ";
+        std::cout << "[LICENSE: Mozilla Public License 2.0]\n";
+        std::cout << "Type \"(quit)\" to quit.\n";
+    }
+
+    int Repl::count_open_parentheses(std::string line)
+    {
+        int open_parentheses = 0;
+
+        for(char& c: line)
+        {
+            switch(c)
+            {
+                case '(': open_parentheses++; break;
+                case ')': open_parentheses--; break;
+            }
+        }
+
+        return open_parentheses;
     }
 }

--- a/src/REPL/Repl.cpp
+++ b/src/REPL/Repl.cpp
@@ -1,6 +1,7 @@
 #include <Ark/REPL/Repl.hpp>
 
-namespace Ark {
+namespace Ark
+{
     void Repl::run()
     {
         const std::string new_prompt = ">> ";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main(int argc, char** argv)
             
             case mode::repl:
             {
-                Ark::Repl repl(options);
+                Ark::Repl repl(options, lib_dir);
                 repl.run();
                 break;
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -94,7 +94,7 @@ int main(int argc, char** argv)
             
             case mode::repl:
             {
-                Ark::Repl repl;
+                Ark::Repl repl(options);
                 repl.run();
                 break;
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,7 @@ int main(int argc, char** argv)
 {
     using namespace clipp;
 
-    enum class mode { help, dev_info, bytecode_reader, version, run };
+    enum class mode { help, dev_info, bytecode_reader, version, run, repl };
     mode selected = mode::help;
 
     std::string file = "", lib_dir = "";
@@ -33,6 +33,7 @@ int main(int argc, char** argv)
         option("-h", "--help").set(selected, mode::help).doc("Display this message")
         | option("--version").set(selected, mode::version).doc("Display ArkScript version and exit")
         | option("--dev-info").set(selected, mode::dev_info).doc("Display development information and exit")
+        | option("-r", "--repl").set(selected, mode::repl).doc("Run the ArkScript REPL")
         | (
             value("file", file).set(selected, mode::run)
             , (
@@ -90,6 +91,13 @@ int main(int argc, char** argv)
                 std::cout << "sizeof(char)            = " << sizeof(char) << "B\n";
                 std::cout << std::endl;
                 break;
+            
+            case mode::repl:
+            {
+                Ark::Repl repl;
+                repl.run();
+                break;
+            }
             
             case mode::run:
             {


### PR DESCRIPTION
I've tried to maintain the code style as much as possible, but if you need me to change the style, just let me know.

While implementing the this, I came across two issues. For one of the issues, I just picked a solution and went with it (if you don't like it, then I can change it), and the other one I'm not entirely sure how to solve (perhaps I can figure out a way and submit another PR in the future).

The original issue that you opened about creating the REPL just said to check if the parentheses matched. While this worked fine, there were times while testing the REPL that I wanted to write multiple lines in the even though my parentheses matched.

With just checking for the parentheses, only the following would work.

```
>> (import "Arithmetic.ark") (print (abs -5))
# 5
```

But the code is easier to write if you can add multiple lines, so I added a check for braces as well (just like there are braces in ArkScript source files) and parentheses. Now the following will also work in the REPL as the above one.

```
>> {
..     (import "arithmetic.ark")
..     (print (abs -5))
.. }
# 5
```

The last issue I had was with persisting variables and imports throughout the Repl's instance.

Right now every time a command is issued to the REPL, the compiler, state, and VM are recreated. I did this because if I just kept feeding the state the compiled bytecode, then it would rerun all the previous bytecode.

This would be the problem I'd run into if I didn't create a new State and VM each time:

```
>> (print "Hello world") 
#Hello world

>> (print "Goodbye world")
#Hello world
#Goodbye world
```

If you can think of a way to do avoid this issue while persisting the imports and variables, then let me know and I'll be more than happy to add it!

This would close #34.