### PR TITLE
Fix/repl libdir

### DIFF
--- a/include/Ark/REPL/Repl.hpp
+++ b/include/Ark/REPL/Repl.hpp
@@ -23,8 +23,8 @@ namespace Ark
         uint16_t m_options;
 
         inline void print_repl_header();
-        int count_open_parentheses(std::string& line);
-        int count_open_braces(std::string& line);
+        int count_open_parentheses(const std::string& line);
+        int count_open_braces(const std::string& line);
     };
 }
 

--- a/src/REPL/Repl.cpp
+++ b/src/REPL/Repl.cpp
@@ -78,11 +78,11 @@ namespace Ark
         std::cout << "Type \"(quit)\" to quit." << std::endl;
     }
 
-    int Repl::count_open_parentheses(std::string& line)
+    int Repl::count_open_parentheses(const std::string& line)
     {
         int open_parentheses = 0;
 
-        for(char& c: line)
+        for(const char& c: line)
         {
             switch(c)
             {
@@ -94,11 +94,11 @@ namespace Ark
         return open_parentheses;
     }
 
-    int Repl::count_open_braces(std::string& line)
+    int Repl::count_open_braces(const std::string& line)
     {
         int open_braces = 0;
 
-        for(char& c: line)
+        for(const char& c: line)
         {
             switch(c)
             {

--- a/src/REPL/Repl.cpp
+++ b/src/REPL/Repl.cpp
@@ -11,7 +11,7 @@ namespace Ark
 
         while(true)
         {
-            Ark::Compiler compiler(false);
+            Ark::Compiler compiler(false, m_lib_dir);
             Ark::State state(m_lib_dir);
             Ark::VM vm(&state, m_options);
             state.setDebug(false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,7 +33,11 @@ int main(int argc, char** argv)
         option("-h", "--help").set(selected, mode::help).doc("Display this message")
         | option("--version").set(selected, mode::version).doc("Display ArkScript version and exit")
         | option("--dev-info").set(selected, mode::dev_info).doc("Display development information and exit")
-        | option("-r", "--repl").set(selected, mode::repl).doc("Run the ArkScript REPL")
+        | (
+            option("-r", "--repl").set(selected, mode::repl).doc("Run the ArkScript REPL"),
+            option("-L", "--lib").doc("Define the directory where the Ark standard library is")
+                & value("lib_dir", lib_dir)
+          )
         | (
             value("file", file).set(selected, mode::run)
             , (


### PR DESCRIPTION
While the Repl took in an argument for a standard library in the code, it couldn't actually grab the lib_dir argument from the CLI.

So I expanded the CLI arguments so that the repl option can take in a lib_dir. I was trying to test some library changes in the repl and I noticed that it didn't work.