### PR TITLE
Modified zip function to accept lists of different relative sizes

### DIFF
--- a/lib/Functional/Functional.ark
+++ b/lib/Functional/Functional.ark
@@ -1,17 +1,18 @@
 {
+
+    (import "../Math/Arithmetic.ark")
+
     (let compose (fun (f g)
         (fun (y &f &g) (f (g y)))))
     
     (let zip (fun (a b) {
-        (if (!= (len a) (len b)) nil
-            {
-                (mut c [])
-                (mut idx 0)
-                (while (< idx (len a)) {
-                    (set c (append c [(@ a idx) (@ b idx)]))
-                    (set idx (+ 1 idx))})
-                c
-                })
+        (let m (min (len a) (len b) ))
+        (mut c [])
+        (mut idx 0)
+        (while (< idx m) {
+            (set c (append c [(@ a idx) (@ b idx)]))
+            (set idx (+ 1 idx))})
+        c
     }))
 
     (let map (fun (f L) {

--- a/lib/Functional/Functional.ark
+++ b/lib/Functional/Functional.ark
@@ -1,6 +1,6 @@
 {
 
-    (import "../Math/Arithmetic.ark")
+    (import "Math/Arithmetic.ark")
 
     (let compose (fun (f g)
         (fun (y &f &g) (f (g y)))))

--- a/tests/arithmetic-tests.ark
+++ b/tests/arithmetic-tests.ark
@@ -52,6 +52,8 @@
         (assert (= (sqrt 4) 2) "Math test 12°2 failed")
         (assert (= (abs -1) 1) "Math test 12°3 failed")
         (assert (= (abs 1) 1) "Math test 12°4 failed")
+        (assert (= (min 2 3) 2) "Math test 12°5 failed")
+        (assert (= (max 2 3) 3) "Math test 12°6 failed")
 
         (print "  Math tests passed")
     }))

--- a/tests/functional-tests.ark
+++ b/tests/functional-tests.ark
@@ -10,7 +10,7 @@
         (let a [1 2 3 4])
         (let b [2 3 4 5])
         (let c [1 2 3])
-        (assert (nil? (zip a c)) "Functional test 2 failed")
+        (assert (= (zip a c) [[1 1] [2 2] [3 3]]) "Functional test 2 failed")
         (assert (= (zip a b) [[1 2] [2 3] [3 4] [4 5]]) "Functional test 2°2 failed")
         (assert (= (zip b a) [[2 1] [3 2] [4 3] [5 4]]) "Functional test 2°3 failed")
 

--- a/tests/functional-tests.ark
+++ b/tests/functional-tests.ark
@@ -13,6 +13,7 @@
         (assert (= (zip a c) [[1 1] [2 2] [3 3]]) "Functional test 2 failed")
         (assert (= (zip a b) [[1 2] [2 3] [3 4] [4 5]]) "Functional test 2°2 failed")
         (assert (= (zip b a) [[2 1] [3 2] [4 3] [5 4]]) "Functional test 2°3 failed")
+        (assert (= (zip [] a) []) "Functional test 2°4 failed")
 
         (assert (= (map foo a) [11 12 13 14]) "Functional test 3 failed")
         (assert (= (map foo []) []) "Functional test 3°2 failed")


### PR DESCRIPTION
This also forces the zip function to always return a list, as it would previously return `nil` if the lengths didn't match.