### PR TITLE
Added Product function for Lists

### DIFF
--- a/lib/List/Product.ark
+++ b/lib/List/Product.ark
@@ -1,0 +1,9 @@
+(let product (fun (L) {
+    (mut idx 0)
+    (mut output 1)
+    (while (< idx (len L)) {
+        (set output (* output (@ L idx)))
+        (set idx (+ 1 idx))
+    })
+    output
+}))

--- a/tests/list-tests.ark
+++ b/tests/list-tests.ark
@@ -1,6 +1,7 @@
 {
     (import "List/Sum.ark")
     (import "List/ForEach.ark")
+    (import "List/Product.ark")
 
     (let list-tests (fun () {
         (let a [12 42])
@@ -50,6 +51,9 @@
         })
 
         (forEach [] '(assert true "List test 14°2 failed"))
+
+        (assert (= (product []) 1) "List test 15 failed")
+        (assert (= (product [1 2 3]) 6) "List test 15°2 failed")
 
         (print "  List tests passed")
     }))


### PR DESCRIPTION
Similar behaviour to Sum for lists. The default is the neutral for multiplication, that is 1.