### PR TITLE
Added reduce function

### DIFF
--- a/lib/Functional/Reduce.ark
+++ b/lib/Functional/Reduce.ark
@@ -1,0 +1,9 @@
+(let reduce (fun (function L) {
+    (mut idx 1)
+    (mut output (@ L 0))
+    (while (< idx (len L)) {
+        (set output (function output (@ L idx)))
+        (set idx (+ 1 idx))
+    })
+    output
+}))

--- a/tests/functional-tests.ark
+++ b/tests/functional-tests.ark
@@ -1,5 +1,6 @@
 {
     (import "Functional/Functional.ark")
+    (import "Functional/Reduce.ark")
 
     (let functional-tests (fun () {
         (let foo (fun (a) (+ a 10)))
@@ -17,6 +18,9 @@
 
         (assert (= (map foo a) [11 12 13 14]) "Functional test 3 failed")
         (assert (= (map foo []) []) "Functional test 3°2 failed")
+
+        (let newsum (fun (a b) (+ a b)))
+        (assert (= (reduce newsum [1 2 3]) 6) "Functional test 4 failed")
 
         (print "  Functional tests passed")
     }))


### PR DESCRIPTION
Traditional reduce function in imperative languages (a left fold). The function takes a function -- which itself takes two arguments and returns one element -- and a list.

Then it successively applies the function to the elements in the list, for example with a function `sum` giving the sum of two elements: `(reduce sum [1 2 3 4])` is roughly equivalent to `(((1 + 2) + 3) + 4)`.