### PR TITLE
Fix/repl whitespace and new stdlib function

### DIFF
--- a/include/Ark/REPL/Repl.hpp
+++ b/include/Ark/REPL/Repl.hpp
@@ -25,6 +25,7 @@ namespace Ark
         inline void print_repl_header();
         int count_open_parentheses(const std::string& line);
         int count_open_braces(const std::string& line);
+        std::string Repl::trim_whitespace(const std::string& str);
     };
 }
 

--- a/include/Ark/REPL/Repl.hpp
+++ b/include/Ark/REPL/Repl.hpp
@@ -25,7 +25,7 @@ namespace Ark
         inline void print_repl_header();
         int count_open_parentheses(const std::string& line);
         int count_open_braces(const std::string& line);
-        std::string Repl::trim_whitespace(const std::string& str);
+        void trim_whitespace(std::string& line);
     };
 }
 

--- a/lib/Functional/Functional.ark
+++ b/lib/Functional/Functional.ark
@@ -23,4 +23,16 @@
         })
         output
     }))
+
+    (let filter (fun (f L) {
+        (mut idx 0)
+        (mut output [])
+        (while (< idx (len L)) {
+            (if (= true (f (@ L idx)))
+                (set output (append output (@ L idx)))
+                nil)
+            (set idx (+ 1 idx))
+        })
+        output
+    }))
 }

--- a/src/REPL/Repl.cpp
+++ b/src/REPL/Repl.cpp
@@ -23,7 +23,9 @@ namespace Ark
             std::cout << new_prompt;
             for(std::string line; std::getline(std::cin, line);)
             {
-                if (line.length() == 0)
+                line = trim_whitespace(line);
+
+                if (line.length() == 0 || line.at(0) == '#')
                 {
                     std::cout << (new_command ? new_prompt : continuing_prompt);
                     continue;
@@ -92,5 +94,17 @@ namespace Ark
         }
 
         return open_braces;
+    }
+
+    std::string Repl::trim_whitespace(const std::string& str)
+    {
+        size_t string_begin = str.find_first_not_of(" \t");
+        if (std::string::npos == string_begin)
+        {
+            return str;
+        }
+
+        size_t string_end = str.find_last_not_of(" \t");
+        return str.substr(string_begin, (string_end - string_begin + 1));
     }
 }

--- a/src/REPL/Repl.cpp
+++ b/src/REPL/Repl.cpp
@@ -23,7 +23,7 @@ namespace Ark
             std::cout << new_prompt;
             for(std::string line; std::getline(std::cin, line);)
             {
-                line = trim_whitespace(line);
+                trim_whitespace(line);
 
                 if (line.length() == 0 || line.at(0) == '#')
                 {
@@ -96,15 +96,13 @@ namespace Ark
         return open_braces;
     }
 
-    std::string Repl::trim_whitespace(const std::string& str)
+    void Repl::trim_whitespace(std::string& line)
     {
-        size_t string_begin = str.find_first_not_of(" \t");
-        if (std::string::npos == string_begin)
+        size_t string_begin = line.find_first_not_of(" \t");
+        if (std::string::npos != string_begin)
         {
-            return str;
+            size_t string_end = line.find_last_not_of(" \t");
+            line = line.substr(string_begin, (string_end - string_begin + 1));
         }
-
-        size_t string_end = str.find_last_not_of(" \t");
-        return str.substr(string_begin, (string_end - string_begin + 1));
     }
 }


### PR DESCRIPTION
This is for #53 that was opened a few days ago.

The REPL will now ignore the line if it is just a comment or whitespace.

I also added a filter function to the standard library, so you can enter in something like the following:

```
(import "Functional/Functional.ark")

(let L [1 2 3 4 5 6 7 8 9 10])
(print (filter (fun (x) (= 0 (mod x 2))) L))
# [2 4 6 8 10]
```