### PR TITLE
Enhancement/stdlib functional

### DIFF
--- a/lib/Functional/Functional.ark
+++ b/lib/Functional/Functional.ark
@@ -3,6 +3,9 @@
 
     (let compose (fun (f g)
         (fun (y &f &g) (f (g y)))))
+
+    (let flip (fun (f a)
+        (fun (b &f &a) (f b a))))
     
     (let zip (fun (a b) {
         (let m (min (len a) (len b) ))

--- a/lib/Functional/Functional.ark
+++ b/lib/Functional/Functional.ark
@@ -14,6 +14,19 @@
         c
     }))
 
+    (let unzip (fun (L) {
+        (let m (len L))
+        (mut list1 [])
+        (mut list2 [])
+        (mut idx 0)
+        (while (< idx m) {
+            (mut current (@ L idx))
+            (set list1 (append list1 (@ current 0)))
+            (set list2 (append list2 (@ current 1)))
+            (set idx (+ 1 idx))})
+        [list1 list2]
+    }))
+
     (let map (fun (f L) {
         (mut idx 0)
         (mut output [])

--- a/lib/Functional/List.ark
+++ b/lib/Functional/List.ark
@@ -1,0 +1,21 @@
+{
+    (let take (fun (n L) {
+        (mut idx 0)
+        (mut output [])
+        (while (and (< idx n) (< idx (len L))) {
+            (set output (append output (@ L idx)))
+            (set idx (+ 1 idx))
+        })
+        output
+    }))
+
+    (let drop (fun (n L) {
+        (mut idx n)
+        (mut output [])
+        (while (< idx (len L)) {
+            (set output (append output (@ L idx)))
+            (set idx (+ 1 idx))
+        })
+        output
+    }))
+}

--- a/lib/Functional/List.ark
+++ b/lib/Functional/List.ark
@@ -18,4 +18,34 @@
         })
         output
     }))
+
+    (let takeWhile (fun (f L) {
+        (mut idx 0)
+        (mut output [])
+        (mut continue true)
+
+        (while (and (< idx (len L)) continue) {
+            (if (= true (f (@ L idx)))
+                {
+                  (set output (append output (@ L idx)))
+                  (set idx (+ 1 idx))
+                }
+                (set continue false)
+            )
+        })
+        output
+    }))
+
+    (let dropWhile (fun (f L) {
+        (mut n 0)
+        (mut output [])
+        (mut continue true)
+
+        (while (and (< n (len L)) continue) {
+            (if (= true (f (@ L n)))
+                (set n (+ 1 n))
+                (set continue false))
+        })
+        (drop n L)
+    }))
 }

--- a/lib/Math/Arithmetic.ark
+++ b/lib/Math/Arithmetic.ark
@@ -20,4 +20,10 @@
             a
             b
         )))
+
+    (let even (fun (n)
+        (= 0 (mod n 2))))
+
+    (let odd (fun (n)
+        (= 1 (mod n 2))))
 }

--- a/lib/Math/Arithmetic.ark
+++ b/lib/Math/Arithmetic.ark
@@ -25,5 +25,5 @@
         (= 0 (mod n 2))))
 
     (let odd (fun (n)
-        (= 1 (mod n 2))))
+        (= 1 (abs (mod n 2)))))
 }

--- a/src/REPL/Repl.cpp
+++ b/src/REPL/Repl.cpp
@@ -32,22 +32,21 @@ namespace Ark
                 }
 
                 if (line.compare("(quit)") == 0)
-                {
                     return;
-                }
 
                 code << line << "\n";
                 open_parentheses += count_open_parentheses(line);
                 open_braces += count_open_braces(line);
 
                 if (open_parentheses == 0 && open_braces == 0)
-                {
                     break;
-                }
 
                 new_command = false;
                 std::cout << continuing_prompt;
             }
+
+            if (std::cin.eof())
+                return;
 
             if (state.doString("{" + code.str() + "}"))
                 vm.run();

--- a/tests/arithmetic-tests.ark
+++ b/tests/arithmetic-tests.ark
@@ -60,6 +60,14 @@
         (assert_ (= (min 2 3) 2) "Math test 12°5 failed")
         (assert_ (= (max 2 3) 3) "Math test 12°6 failed")
 
+        (assert_ (= (even 2) true) "Math test 13 failed")
+        (assert_ (= (even 1000) true) "Math test 13°2 failed")
+        (assert_ (= (even 9) false) "Math test 13°3 failed")
+        (assert_ (= (odd 9) true) "Math test 13°4 failed")
+        (assert_ (= (odd -1) true) "Math test 13°5 failed")
+        (assert_ (= (odd 2) false) "Math test 13°6 failed")
+        (assert_ (= (odd 0) false) "Math test 13°6 failed")
+
         (recap "Math tests passed" tests (- (time) start-time))
 
         tests

--- a/tests/arithmetic-tests.ark
+++ b/tests/arithmetic-tests.ark
@@ -66,7 +66,7 @@
         (assert_ (= (odd 9) true) "Math test 13°4 failed")
         (assert_ (= (odd -1) true) "Math test 13°5 failed")
         (assert_ (= (odd 2) false) "Math test 13°6 failed")
-        (assert_ (= (odd 0) false) "Math test 13°6 failed")
+        (assert_ (= (odd 0) false) "Math test 13°7 failed")
 
         (recap "Math tests passed" tests (- (time) start-time))
 

--- a/tests/functional-tests.ark
+++ b/tests/functional-tests.ark
@@ -40,6 +40,21 @@
             (fun (err) { (assert_ (= err "cannot divide by zero") "Functional test 5°2 failed") })
         )
 
+        (assert_ (= (unzip (zip a c)) [[1 2 3] [1 2 3]]) "Functional test 6 failed")
+        (assert_ (= (unzip (zip a b)) [[1 2 3 4] [2 3 4 5]]) "Functional test 6°2 failed")
+        (assert_ (= (unzip (zip b a)) [[2 3 4 5] [1 2 3 4]]) "Functional test 6°3 failed")
+        (assert_ (= (unzip (zip [] a)) [[] []]) "Functional test 6°4 failed")
+
+        (let oneThroughTen [1 2 3 4 5 6 7 8 9 10])
+        (assert_ (= (filter (fun (x) (= 0 (mod x 2))) oneThroughTen) [2 4 6 8 10]) "Functional test 7 failed")
+        (assert_ (= (filter (fun (x) (> x 5)) oneThroughTen) [6 7 8 9 10]) "Functional test 7°2 failed")
+        (assert_ (= (filter (fun (x) (true)) []) []) "Functional test 7°3 failed")
+
+        (let div (fun (x y) (/ x y)))
+        (let divBy5 (flip div 5))
+
+        (assert_ (= (divBy5 10) 2) "Functional test 8 failed")
+
         (recap "Functional tests passed" tests (- (time) start-time))
 
         tests


### PR DESCRIPTION
I've added some more functions to the standard library.

Math/Arithmetic:
- even
- odd

Functional/Functional:
- flip
- unzip

Functional/List:
- take
- drop
- takeWhile
- dropWhile

I was not sure what to call "Functional/List" at first, but I figured that since they are manipulating lists, it's appropriate to call it "Functional/List".

Here are some examples of those functions:

**take** -- takes _n_ amount of elements from a list
```
(import "Functional/List.ark") 
(print (take 2 [1 2 3 4 5 6 7 8 9 10]))
# [1 2]
```

**drop** -- drops _n_ amount of elements from a list
```
(import "Functional/List.ark") 
(print (drop 2 [1 2 3 4 5 6 7 8 9 10]))
# [3 4 5 6 7 8 9 10]
```

**takeWhile** -- takes elements from a list while the predicate returns true
```
(import "Functional/List.ark")
 (print (takeWhile (fun (n) (< n 5)) [1 2 3 4 5 6 7 8 9 10]))
# [1 2 3 4]
```

**dropWhile** -- drops elements from a list while the predicate returns true
```
(import "Functional/List.ark") 
(print (dropWhile (fun (n) (< n 5)) [1 2 3 4 5 6 7 8 9 10]))
# [5 6 7 8 9 10]
```

The even and odd functions in Math/Arithmetic seemed like low hanging fruit to just knock out. I found myself writing even/odd functions while testing these other functions (filter, dropWhile, etc.), so I figured I'd just add them.

I also added flip and unzip to Functional/Functional.

I have not written tests for Functional/List yet just because I wasn't sure if you were happy with the naming. If you are, then we may also want to think about bringing `map`, `filter`, and `reduce` over to Functional/List.ark since those are functions related to lists.

---
EDIT by SuperFola: replaced `take` by `drop` in your example for `drop`